### PR TITLE
Remove unnecessary `begin`s from CLI code

### DIFF
--- a/lib/solusvm/cli/client_cli.rb
+++ b/lib/solusvm/cli/client_cli.rb
@@ -40,9 +40,7 @@ module Solusvm
     private
 
     def api
-      @client ||= begin
-        Solusvm::Client.new(api_params())
-      end
+      @client ||= Solusvm::Client.new(api_params())
     end
   end
 end

--- a/lib/solusvm/cli/general_cli.rb
+++ b/lib/solusvm/cli/general_cli.rb
@@ -19,9 +19,7 @@ module Solusvm
     private
 
     def api
-      @general ||= begin
-        Solusvm::General.new(api_params)
-      end
+      @general ||= Solusvm::General.new(api_params)
     end
   end
 end

--- a/lib/solusvm/cli/node_cli.rb
+++ b/lib/solusvm/cli/node_cli.rb
@@ -34,9 +34,7 @@ module Solusvm
     private
 
     def api
-      @node ||= begin
-        Solusvm::Node.new(api_params)
-      end
+      @node ||= Solusvm::Node.new(api_params)
     end
   end
 end

--- a/lib/solusvm/cli/reseller_cli.rb
+++ b/lib/solusvm/cli/reseller_cli.rb
@@ -64,9 +64,7 @@ module Solusvm
     private
 
     def api
-      @reseller ||= begin
-        Solusvm::Reseller.new(api_params)
-      end
+      @reseller ||= Solusvm::Reseller.new(api_params)
     end
   end
 end

--- a/lib/solusvm/cli/server_cli.rb
+++ b/lib/solusvm/cli/server_cli.rb
@@ -149,9 +149,7 @@ module Solusvm
     private
 
     def api
-      @server ||= begin
-        Solusvm::Server.new(api_params)
-      end
+      @server ||= Solusvm::Server.new(api_params)
     end
 
     def switch(vserverid, switch_value, on_method, off_method)


### PR DESCRIPTION
These blocks used to call `configure` but don't anymore, so there is no reason for `begin..end`
