### PR TITLE
Roll back required faraday version

### DIFF
--- a/solusvm.gemspec
+++ b/solusvm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
 
   s.add_runtime_dependency 'thor', '>= 0.18.1'
-  s.add_runtime_dependency 'faraday', '~> 0.9.0'
+  s.add_runtime_dependency 'faraday', '~> 0.8.9'
   s.add_runtime_dependency 'jruby-openssl' if RUBY_PLATFORM == 'java'
 
   s.add_development_dependency 'mocha', '~> 1.0.0'


### PR DESCRIPTION
faraday_middleware isn't up to date yet. That breaks some projects where we
use faraday_middleware and this gem.
