### PR TITLE
Remove support for deprecated `vserver-consolepass` command

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,7 +96,6 @@ Tasks:
     solusvm server addip VSERVERID                            # Adds an ip to the server
     solusvm server boot VSERVERID                             # Boots up a server
     solusvm server change-bootorder VSERVERID BOOTORDER       # Changes the boot order of a server [cd(Hard Disk CDROM)|dc(CDROM Hard Disk)|c(Hard Di...
-    solusvm server change-consolepass VSERVERID NEWPASSWORD   # Changes the console password of a server
     solusvm server change-hostname VSERVERID HOSTNAME         # Changes the hostname of a server
     solusvm server change-owner VSERVERID CLIENTID            # Changes the owner of a server
     solusvm server change-plan VSERVERID NEWPLAN              # Changes the plan of a server

--- a/lib/solusvm/cli/server_cli.rb
+++ b/lib/solusvm/cli/server_cli.rb
@@ -36,11 +36,6 @@ module SolusVM
       output api.change_owner(vserverid, clientid)
     end
 
-    desc "change-consolepass VSERVERID NEWPASSWORD", "Changes the console password of a server"
-    def change_consolepass(vserverid, newpassword)
-      output api.change_consolepass(vserverid, newpassword)
-    end
-
     desc "change-vncpass VSERVERID NEWPASSWORD", "Changes the vnc password of a server"
     def change_vncpass(vserverid, newpassword)
       output api.change_vncpass(vserverid, newpassword)

--- a/lib/solusvm/server.rb
+++ b/lib/solusvm/server.rb
@@ -207,16 +207,6 @@ module SolusVM
       perform_request(action: 'vserver-changeowner', vserverid: vid, clientid: client_id)
     end
 
-    # Public: Changes server console password.
-    #
-    # vid          - The virtual server ID in SolusVM
-    # new_password - The new console password
-    #
-    # Returns true if the server's console password was successfully changed.
-    def change_consolepass(vid, new_password)
-      perform_request(action: 'vserver-consolepass', vserverid: vid, consolepassword: new_password)
-    end
-
     # Public: Changes server VNC password.
     #
     # vid          - The virtual server ID in SolusVM

--- a/test/cli/test_server_cli.rb
+++ b/test/cli/test_server_cli.rb
@@ -40,16 +40,6 @@ class TestServerCLI < Test::Unit::TestCase
     SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-owner", "thevserverid", "thenewowner"]))
   end
 
-  def test_should_delegate_server_change_consolepass_to_server
-    SolusVM::Server.stubs(:new).with(@solusvm_params).returns(mock do
-      expects(:successful?).returns(true)
-      expects(:change_consolepass).with("thevserverid", "thenewpass").returns("theresult")
-    end)
-
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-consolepass", "thevserverid", "thenewpass"]))
-  end
-
   def test_should_delegate_server_change_vncpass_to_server
     SolusVM::Server.stubs(:new).with(@solusvm_params).returns(mock do
       expects(:successful?).returns(true)

--- a/test/solusvm/test_server.rb
+++ b/test/solusvm/test_server.rb
@@ -167,14 +167,6 @@ class TestServer < Test::Unit::TestCase
     assert @server.successful?
   end
 
-  def test_change_consolepass
-    pend do
-      stub_response 'server/change-consolepass'
-
-      assert @server.change_consolepass(1, 'thepassword')
-    end
-  end
-
   def test_change_vncpass
     stub_response 'server/change-vncpass'
 


### PR DESCRIPTION
Closes #69
