### PR TITLE
Add a specific IP to a VM

### DIFF
--- a/lib/solusvm/cli/server_cli.rb
+++ b/lib/solusvm/cli/server_cli.rb
@@ -56,9 +56,9 @@ module SolusVM
       output api.change_hostname(vserverid, newhostname)
     end
 
-    desc "addip VSERVERID", "Adds an ip to the server"
-    def addip(vserverid)
-      output api.add_ip(vserverid)
+    desc "addip VSERVERID [ip]", "Adds an ip to the server"
+    def addip(vserverid, ip = nil)
+      output api.add_ip(vserverid, ip)
     end
 
     desc "boot VSERVERID", "Boots up a server"

--- a/lib/solusvm/server.rb
+++ b/lib/solusvm/server.rb
@@ -170,10 +170,11 @@ module SolusVM
     # Public: Adds an IP address for a specific server.
     #
     # vid - The virtual server ID in SolusVM
+    # ip  - Specific IPv4 address to add (optional)
     #
     # Returns the IP as a String.
-    def add_ip(vid)
-      perform_request(action: 'vserver-addip', vserverid: vid)
+    def add_ip(vid, ip = nil)
+      perform_request(action: 'vserver-addip', vserverid: vid, ipv4addr: ip)
       returned_parameters['ipaddress']
     end
 

--- a/test/cli/test_server_cli.rb
+++ b/test/cli/test_server_cli.rb
@@ -97,11 +97,11 @@ class TestServerCLI < Test::Unit::TestCase
   def test_should_delegate_server_add_ip_to_server
     SolusVM::Server.stubs(:new).with(@solusvm_params).returns(mock do
       expects(:successful?).returns(true)
-      expects(:add_ip).with("thevserverid").returns("theresult")
+      expects(:add_ip).with("thevserverid", "ipv4addr").returns("theresult")
     end)
 
     out = capture_stdout do
-      SolusVM::CLI.start(cli_expand_base_arguments(["server", "addip", "thevserverid"]))
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "addip", "thevserverid", "ipv4addr"]))
     end
     assert_match "theresult", out.string
   end

--- a/test/solusvm/test_server.rb
+++ b/test/solusvm/test_server.rb
@@ -146,6 +146,13 @@ class TestServer < Test::Unit::TestCase
     assert @server.successful?
   end
 
+  def test_add_specific_ip
+    stub_response 'server/add-ip'
+
+    assert_equal '123.123.123.123', @server.add_ip(1, '123.123.123.123')
+    assert @server.successful?
+  end
+
   def test_del_ip
     stub_response 'server/del-ip'
 


### PR DESCRIPTION
In `SolusVM v1.15.00+` we have the option to [specify a single IPv4 address to add](http://docs.solusvm.com/v2/Default.htm#Developer/Admin-Api/Virtual-Server-Functions/Add-Ipaddress.htm)

Adds the option to specify the IP. 
