### PR TITLE
Upgrade thor to 0.19.1 and refactor tests

### DIFF
--- a/solusvm.gemspec
+++ b/solusvm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files   = Dir['test/**/*']
   s.executables  = "solusvm"
 
-  s.add_runtime_dependency 'thor', '~> 0.18.1'
+  s.add_runtime_dependency 'thor', '~> 0.19.1'
   s.add_runtime_dependency 'faraday', '~> 0.8.9'
 
   s.add_development_dependency 'mocha', '~> 1.0.0'

--- a/test/cli/test_client_cli.rb
+++ b/test/cli/test_client_cli.rb
@@ -27,16 +27,18 @@ class TestClientCLI < Test::Unit::TestCase
     end
     SolusVM::Client.expects(:new).with(solusvm_params).returns(api)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments([
-      "client", "create",
-      "--username", "theusername",
-      "--password", "thepassword",
-      "--email", "theemail",
-      "--firstname", "thefirstname",
-      "--lastname", "thelastname",
-      "--company", "thecompany"
-    ]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments([
+        "client", "create",
+        "--username", "theusername",
+        "--password", "thepassword",
+        "--email", "theemail",
+        "--firstname", "thefirstname",
+        "--lastname", "thelastname",
+        "--company", "thecompany"
+      ]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_client_change_password_to_client
@@ -45,8 +47,10 @@ class TestClientCLI < Test::Unit::TestCase
       expects(:change_password).with("theusername", "thepassword").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["client", "change-password", "theusername", "thepassword"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["client", "change-password", "theusername", "thepassword"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_client_authenticate_to_client
@@ -55,8 +59,10 @@ class TestClientCLI < Test::Unit::TestCase
       expects(:authenticate).with("theusername", "thepassword").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["client", "authenticate", "theusername", "thepassword"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["client", "authenticate", "theusername", "thepassword"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_client_check_exists_to_client
@@ -65,8 +71,10 @@ class TestClientCLI < Test::Unit::TestCase
       expects(:exists?).with("theusername").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["client", "check-exists", "theusername"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["client", "check-exists", "theusername"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_client_delete_to_client
@@ -75,8 +83,10 @@ class TestClientCLI < Test::Unit::TestCase
       expects(:delete).with("theusername").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["client", "delete", "theusername"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["client", "delete", "theusername"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_client_list_to_client
@@ -85,7 +95,9 @@ class TestClientCLI < Test::Unit::TestCase
       expects(:list).returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["client", "list"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["client", "list"]))
+    end
+    assert_match "theresult", out.string
   end
 end

--- a/test/cli/test_general_cli.rb
+++ b/test/cli/test_general_cli.rb
@@ -15,8 +15,10 @@ class TestGeneralCLI < Test::Unit::TestCase
       expects(:templates).with("type").returns("thetemplates")
     end)
 
-    $stdout.expects(:puts).with("thetemplates")
-    SolusVM::CLI.start(cli_expand_base_arguments(["general", "templates", "type"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["general", "templates", "type"]))
+    end
+    assert_match "thetemplates", out.string
   end
 
   def test_should_delegate_plans_to_general
@@ -25,8 +27,10 @@ class TestGeneralCLI < Test::Unit::TestCase
       expects(:plans).with("type").returns("theplans")
     end)
 
-    $stdout.expects(:puts).with("theplans")
-    SolusVM::CLI.start(cli_expand_base_arguments(["general", "plans", "type"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["general", "plans", "type"]))
+    end
+    assert_match "theplans", out.string
   end
 
   def test_should_delegate_isos_to_general
@@ -35,7 +39,9 @@ class TestGeneralCLI < Test::Unit::TestCase
       expects(:isos).with("type").returns("theisos")
     end)
 
-    $stdout.expects(:puts).with("theisos")
-    SolusVM::CLI.start(cli_expand_base_arguments(["general", "isos", "type"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["general", "isos", "type"]))
+    end
+    assert_match "theisos", out.string
   end
 end

--- a/test/cli/test_node_cli.rb
+++ b/test/cli/test_node_cli.rb
@@ -15,8 +15,10 @@ class TestNodeCLI < Test::Unit::TestCase
       expects(:available_ips).with("thevserverid").returns("theips")
     end)
 
-    $stdout.expects(:puts).with("theips")
-    SolusVM::CLI.start(cli_expand_base_arguments(["node", "available-ips", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["node", "available-ips", "thevserverid"]))
+    end
+    assert_match "theips", out.string
   end
 
   def test_should_delegate_node_stats_to_node
@@ -25,8 +27,10 @@ class TestNodeCLI < Test::Unit::TestCase
       expects(:statistics).with("thevserverid").returns("thestats")
     end)
 
-    $stdout.expects(:puts).with("thestats")
-    SolusVM::CLI.start(cli_expand_base_arguments(["node", "stats", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["node", "stats", "thevserverid"]))
+    end
+    assert_match "thestats", out.string
   end
 
   def test_should_delegate_node_xenresources_to_node
@@ -35,8 +39,10 @@ class TestNodeCLI < Test::Unit::TestCase
       expects(:xenresources).with("thevserverid").returns("theresources")
     end)
 
-    $stdout.expects(:puts).with("theresources")
-    SolusVM::CLI.start(cli_expand_base_arguments(["node", "xenresources", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["node", "xenresources", "thevserverid"]))
+    end
+    assert_match "theresources", out.string
   end
 
   def test_should_delegate_node_virtualservers_to_node
@@ -45,8 +51,10 @@ class TestNodeCLI < Test::Unit::TestCase
       expects(:virtualservers).with("thevserverid").returns("thedata")
     end)
 
-    $stdout.expects(:puts).with("thedata")
-    SolusVM::CLI.start(cli_expand_base_arguments(["node", "virtualservers", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["node", "virtualservers", "thevserverid"]))
+    end
+    assert_match "thedata", out.string
   end
 
   def test_should_delegate_nodes_list_to_node
@@ -55,8 +63,10 @@ class TestNodeCLI < Test::Unit::TestCase
       expects(:list).with("type").returns("thenodes")
     end)
 
-    $stdout.expects(:puts).with("thenodes")
-    SolusVM::CLI.start(cli_expand_base_arguments(["node", "list", "type"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["node", "list", "type"]))
+    end
+    assert_match "thenodes", out.string
   end
 
   def test_should_delegate_nodes_ids_to_node
@@ -65,8 +75,10 @@ class TestNodeCLI < Test::Unit::TestCase
       expects(:ids).with("type").returns("thenodes")
     end)
 
-    $stdout.expects(:puts).with("thenodes")
-    SolusVM::CLI.start(cli_expand_base_arguments(["node", "list-ids", "type"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["node", "list-ids", "type"]))
+    end
+    assert_match "thenodes", out.string
   end
 
 end

--- a/test/cli/test_reseller_cli.rb
+++ b/test/cli/test_reseller_cli.rb
@@ -41,31 +41,33 @@ class TestResellerCLI < Test::Unit::TestCase
       end.returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments([
-      "reseller", "create",
-      "--username", "theusername",
-      "--password", "thepassword",
-      "--email", "theemail",
-      "--firstname", "thefirstname",
-      "--lastname", "thelastname",
-      "--company", "thecompany",
-      "--usernameprefix", "theusernameprefix",
-      "--maxvps", "themaxvps",
-      "--maxusers", "themaxusers",
-      "--maxmem", "themaxmem",
-      "--maxburst", "themaxburst",
-      "--maxdisk", "themaxdisk",
-      "--maxbw", "themaxbw",
-      "--maxipv4", "themaxipv4",
-      "--maxipv6", "themaxipv6",
-      "--nodegroups", "thenodegroups",
-      "--mediagroups", "themediagroups",
-      "--openvz", "theopenvz",
-      "--xenpv", "thexenpv",
-      "--xenhvm", "thexenhvm",
-      "--kvm", "thekvm"
-    ]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments([
+        "reseller", "create",
+        "--username", "theusername",
+        "--password", "thepassword",
+        "--email", "theemail",
+        "--firstname", "thefirstname",
+        "--lastname", "thelastname",
+        "--company", "thecompany",
+        "--usernameprefix", "theusernameprefix",
+        "--maxvps", "themaxvps",
+        "--maxusers", "themaxusers",
+        "--maxmem", "themaxmem",
+        "--maxburst", "themaxburst",
+        "--maxdisk", "themaxdisk",
+        "--maxbw", "themaxbw",
+        "--maxipv4", "themaxipv4",
+        "--maxipv6", "themaxipv6",
+        "--nodegroups", "thenodegroups",
+        "--mediagroups", "themediagroups",
+        "--openvz", "theopenvz",
+        "--xenpv", "thexenpv",
+        "--xenhvm", "thexenhvm",
+        "--kvm", "thekvm"
+      ]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_reseller_change_resources_to_reseller
@@ -93,24 +95,26 @@ class TestResellerCLI < Test::Unit::TestCase
       end.returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments([
-      "reseller", "change-resources",
-      "--maxvps", "themaxvps",
-      "--maxusers", "themaxusers",
-      "--maxmem", "themaxmem",
-      "--maxburst", "themaxburst",
-      "--maxdisk", "themaxdisk",
-      "--maxbw", "themaxbw",
-      "--maxipv4", "themaxipv4",
-      "--maxipv6", "themaxipv6",
-      "--nodegroups", "thenodegroups",
-      "--mediagroups", "themediagroups",
-      "--openvz", "theopenvz",
-      "--xenpv", "thexenpv",
-      "--xenhvm", "thexenhvm",
-      "--kvm", "thekvm"
-    ]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments([
+        "reseller", "change-resources",
+        "--maxvps", "themaxvps",
+        "--maxusers", "themaxusers",
+        "--maxmem", "themaxmem",
+        "--maxburst", "themaxburst",
+        "--maxdisk", "themaxdisk",
+        "--maxbw", "themaxbw",
+        "--maxipv4", "themaxipv4",
+        "--maxipv6", "themaxipv6",
+        "--nodegroups", "thenodegroups",
+        "--mediagroups", "themediagroups",
+        "--openvz", "theopenvz",
+        "--xenpv", "thexenpv",
+        "--xenhvm", "thexenhvm",
+        "--kvm", "thekvm"
+      ]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_reseller_info_to_reseller
@@ -119,8 +123,10 @@ class TestResellerCLI < Test::Unit::TestCase
       expects(:info).with("theusername").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["reseller", "info", "theusername"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["reseller", "info", "theusername"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_reseller_delete_to_reseller
@@ -129,8 +135,10 @@ class TestResellerCLI < Test::Unit::TestCase
       expects(:delete).with("theusername").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["reseller", "delete", "theusername"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["reseller", "delete", "theusername"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_reseller_list_to_reseller
@@ -139,7 +147,9 @@ class TestResellerCLI < Test::Unit::TestCase
      expects(:list).returns("theresult")
    end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["reseller", "list"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["reseller", "list"]))
+    end
+    assert_match "theresult", out.string
   end
 end

--- a/test/cli/test_server_cli.rb
+++ b/test/cli/test_server_cli.rb
@@ -16,8 +16,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:status).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "status", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "status", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_change_plan_to_server
@@ -26,8 +28,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:change_plan).with("thevserverid", "thenewplan").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-plan", "thevserverid", "thenewplan"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-plan", "thevserverid", "thenewplan"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_change_owner_to_server
@@ -36,8 +40,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:change_owner).with("thevserverid", "thenewowner").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-owner", "thevserverid", "thenewowner"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-owner", "thevserverid", "thenewowner"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_change_vncpass_to_server
@@ -46,8 +52,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:change_vncpass).with("thevserverid", "thenewpass").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-vncpass", "thevserverid", "thenewpass"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-vncpass", "thevserverid", "thenewpass"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_change_rootpass_to_server
@@ -56,8 +64,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:change_rootpassword).with("thevserverid", "thenewpass").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-rootpass", "thevserverid", "thenewpass"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-rootpass", "thevserverid", "thenewpass"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_change_bootorder_to_server
@@ -66,8 +76,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:change_bootorder).with("thevserverid", "theneworder").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-bootorder", "thevserverid", "theneworder"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-bootorder", "thevserverid", "theneworder"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_change_hostname_to_server
@@ -76,8 +88,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:change_hostname).with("thevserverid", "thenewhostname").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-hostname", "thevserverid", "thenewhostname"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "change-hostname", "thevserverid", "thenewhostname"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_add_ip_to_server
@@ -86,8 +100,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:add_ip).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "addip", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "addip", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_boot_to_server
@@ -96,8 +112,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:boot).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "boot", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "boot", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_reboot_to_server
@@ -106,8 +124,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:reboot).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "reboot", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "reboot", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_shutdown_to_server
@@ -116,8 +136,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:shutdown).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "shutdown", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "shutdown", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_suspend_to_server
@@ -126,8 +148,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:suspend).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "suspend", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "suspend", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_resume_to_server
@@ -136,8 +160,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:resume).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "resume", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "resume", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_check_exists_to_server
@@ -146,8 +172,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:exists?).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "check-exists", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "check-exists", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_terminate_to_server
@@ -156,8 +184,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:terminate).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "terminate", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "terminate", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_rebuild_to_server
@@ -166,8 +196,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:rebuild).with("thevserverid", template: "thetemplate").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "rebuild", "thevserverid", "--template", "thetemplate"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "rebuild", "thevserverid", "--template", "thetemplate"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_tun_switcher_on_to_server
@@ -176,8 +208,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:tun_enable).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "tun-switcher", "thevserverid", "on"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "tun-switcher", "thevserverid", "on"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_tun_switcher_off_to_server
@@ -186,8 +220,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:tun_disable).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "tun-switcher", "thevserverid", "off"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "tun-switcher", "thevserverid", "off"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_network_switcher_on_to_server
@@ -196,8 +232,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:network_enable).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "network-switcher", "thevserverid", "on"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "network-switcher", "thevserverid", "on"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_network_switcher_off_to_server
@@ -206,8 +244,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:network_disable).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "network-switcher", "thevserverid", "off"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "network-switcher", "thevserverid", "off"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_pae_switcher_on_to_server
@@ -216,8 +256,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:pae_enable).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "pae-switcher", "thevserverid", "on"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "pae-switcher", "thevserverid", "on"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_pae_switcher_off_to_server
@@ -226,8 +268,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:pae_disable).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "pae-switcher", "thevserverid", "off"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "pae-switcher", "thevserverid", "off"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_info_to_server
@@ -236,8 +280,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:info).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "info", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "info", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_vnc_to_server
@@ -246,8 +292,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:vnc).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "vnc", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "vnc", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_console_to_server
@@ -256,8 +304,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:console).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "console", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "console", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_info_all_to_server
@@ -266,8 +316,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:info_all).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "info-all", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "info-all", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_mountiso_to_server
@@ -276,8 +328,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:mountiso).with("thevserverid", "theiso").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "mountiso", "thevserverid", "theiso"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "mountiso", "thevserverid", "theiso"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_unmountiso_to_server
@@ -286,8 +340,10 @@ class TestServerCLI < Test::Unit::TestCase
       expects(:unmountiso).with("thevserverid").returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments(["server", "unmountiso", "thevserverid"]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments(["server", "unmountiso", "thevserverid"]))
+    end
+    assert_match "theresult", out.string
   end
 
   def test_should_delegate_server_create_to_server
@@ -300,17 +356,19 @@ class TestServerCLI < Test::Unit::TestCase
       ).returns("theresult")
     end)
 
-    $stdout.expects(:puts).with("theresult")
-    SolusVM::CLI.start(cli_expand_base_arguments([
-      "server", "create",
-      "thehostname",
-      "thepassword",
-      "--plan", "theplan",
-      "--ips", "theips",
-      "--kind", "thekind",
-      "--username", "theusername",
-      "--template", "thetemplate",
-      "--node", "thenode"
-    ]))
+    out = capture_stdout do
+      SolusVM::CLI.start(cli_expand_base_arguments([
+        "server", "create",
+        "thehostname",
+        "thepassword",
+        "--plan", "theplan",
+        "--ips", "theips",
+        "--kind", "thekind",
+        "--username", "theusername",
+        "--template", "thetemplate",
+        "--node", "thenode"
+      ]))
+    end
+    assert_match "theresult", out.string
   end
 end

--- a/test/solusvm/test_cli.rb
+++ b/test/solusvm/test_cli.rb
@@ -10,8 +10,8 @@ class TestCLI < Test::Unit::TestCase
   end
 
   def test_should_print_version
-    $stdout.expects(:puts).with(SolusVM::VERSION)
-    SolusVM::CLI.start %W(version)
+    out = capture_stdout { SolusVM::CLI.start %W(version) }
+    assert_match SolusVM::VERSION, out.string
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,24 @@
+require 'stringio'
 require 'test/unit'
 require 'solusvm'
 require 'mocha/setup'
 require 'sham_rack'
 require 'set'
 require 'json'
+
+module Kernel
+  # Public: Redirect $stdout to an instance of StringIO.
+  #
+  # Returns the captured output as a StringIO.
+  def capture_stdout
+    out = StringIO.new
+    $stdout = out
+    yield
+    return out
+  ensure
+    $stdout = STDOUT
+  end
+end
 
 class Test::Unit::TestCase
   # Public: Stubs a JSON reponse using ShamRack.


### PR DESCRIPTION
Upgrades Thor to 0.19.1 and refactors the tests to capture output from `puts` as suggested in http://goo.gl/eHtBnl

Fixes #87 
